### PR TITLE
[FEAT] 비밀번호 암호화 - #3

### DIFF
--- a/BookAt-Service.zip_expanded/BookAt-Service/src/main/java/com/bookat/config/SecurityConfig.java
+++ b/BookAt-Service.zip_expanded/BookAt-Service/src/main/java/com/bookat/config/SecurityConfig.java
@@ -3,6 +3,8 @@ package com.bookat.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -20,5 +22,10 @@ public class SecurityConfig {
             );
 
         return http.build();
+    }
+    
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+    	return new BCryptPasswordEncoder();
     }
 }

--- a/BookAt-Service.zip_expanded/BookAt-Service/src/main/java/com/bookat/controller/UserSignupController.java
+++ b/BookAt-Service.zip_expanded/BookAt-Service/src/main/java/com/bookat/controller/UserSignupController.java
@@ -11,6 +11,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -41,6 +42,9 @@ public class UserSignupController {
 	@Value("${portone.api_secret}")
 	private String portoneApiSecret;
     
+	@Autowired
+	private PasswordEncoder passwordEncoder;
+	
 	// 회원가입 페이지로 이동 
 	@GetMapping("/user/signup")
 	public String signupVerification(Model model) {
@@ -135,6 +139,10 @@ public class UserSignupController {
 		System.out.println("전화번호 포맷 변경 : "+phone+" -> "+formattedPhone);
 		
 		input.setPhone(formattedPhone);
+		
+		// 비밀번호 암호화 
+		String encodedPassword = passwordEncoder.encode(input.getUserPw());
+		input.setUserPw(encodedPassword);
 		
 		int res = service.insertUser(input);
 		


### PR DESCRIPTION
## 📌 PR 제목
입력받은 비밀번호를 단방향 암호화(해싱)하여 데이터베이스에 저장합니다.

## ✨ 작업 내용
<!-- 이번 PR에서 추가/변경된 내용을 적어주세요 -->
- [x] 비밀번호 암호화

## 🔍 관련 이슈
- close #3 

## 🧪 테스트 방법
1. [x] 로컬에서 실행 확인

## 💬 기타 참고 사항
단방향 암호화(해싱)의 장단점

> 장점 
> - 복구 불가능성 
> : 원래의 비밀번호를 계산해낼 수 없다. 만약 데이터베이스가 해킹당해 회원 정보가 유출되더라도, 공격자는 암호화된 값만 얻게 될 뿐 실제 비밀번호는 알 수 없다.
> - 솔트를 통한 보안 강화 
> : `BCryptPasswordEncoder`와 같은 암호화 방식은 내부적으로 솔트라는 임의의 값을 비밀번호에 추가하여 암호화한다. 두 명의 사용자가 똑같은 번호를 사용하더라도, 데이터베이스에 저장되는 암호화된 값은 완전히 다르다.
> - 검증의 안정성
> : 사용자가 로그인을 시도할 때, 서버는 입력된 비밀번호를 똑같은 방식으로 암호화한 뒤, DB에 저장된 암호화된 값과 비교한다.

<br>

>단점
>- 비밀번호 찾기 기능 구현 불가능 
>: 암호화된 값에서 원래 비밀번호를 복구할 수 없기 때문에, 비밀번호 재설정 기능을 제공해야 한다.
>- 데이터베이스 이전의 복잡성
>: 다른 시스템에서 회원 정보를 이전해와야 할 때, 이전 시스템이 다른 암호화 방식을 사용했다면 비밀번호를 그대로 옮길 수 없다.
