### PR TITLE
헤더 파일을 붙이지 않는 모달이나 팝업창 용 사용자검증 파일 추가 (userAuthModal.js) - #16

### DIFF
--- a/BookAt-Service.zip_expanded/BookAt-Service/src/main/java/com/bookat/config/SecurityConfig.java
+++ b/BookAt-Service.zip_expanded/BookAt-Service/src/main/java/com/bookat/config/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
 //        .httpBasic(Customizer.withDefaults())
         .authorizeHttpRequests(auth -> auth
         		.requestMatchers("/css/**", "/js/**", "/images/**").permitAll()	// 정적 리소스 접근 가능
-        		.requestMatchers("/", "/user/**", "/auth/**").permitAll()		// 로그인 전 접근 가능 (페이지들)
+        		.requestMatchers("/", "/user/**", "/auth/**", "/queue/**").permitAll()		// 토큰없이 접근 허용
         		.requestMatchers("/api/**").authenticated()						// 기능들
                 .anyRequest().denyAll()
         ).addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/BookAt-Service.zip_expanded/BookAt-Service/src/main/java/com/bookat/controller/UserAuthController.java
+++ b/BookAt-Service.zip_expanded/BookAt-Service/src/main/java/com/bookat/controller/UserAuthController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+import com.bookat.dto.UserInfoResponse;
 import com.bookat.dto.UserLoginResponse;
 import com.bookat.entity.User;
 import com.bookat.service.impl.UserLoginServiceImpl;
@@ -49,7 +50,18 @@ public class UserAuthController {
 	    userId = jwtTokenProvider.getUserIdFromToken(token);
 	    User user = service.findUserById(userId);
 	    
-	    return ResponseEntity.ok(Map.of("userId", user.getUserId(), "userName", user.getUserName()));
+	    if(user == null) {
+	    	return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("존재하지 않는 사용자입니다.");
+	    }
+	    
+	    UserInfoResponse userInfo = new UserInfoResponse();
+	    userInfo.setUserId(user.getUserId());
+	    userInfo.setUserName(user.getUserName());
+	    userInfo.setPhone(user.getPhone());
+	    userInfo.setBirth(user.getBirth());
+	    userInfo.setEmail(user.getEmail());
+	    
+	    return ResponseEntity.ok(userInfo);
 	}
 	
 	// access token 재발급

--- a/BookAt-Service.zip_expanded/BookAt-Service/src/main/java/com/bookat/dto/UserInfoResponse.java
+++ b/BookAt-Service.zip_expanded/BookAt-Service/src/main/java/com/bookat/dto/UserInfoResponse.java
@@ -1,0 +1,16 @@
+package com.bookat.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class UserInfoResponse {
+	
+	private String userId;
+	private String userName;
+	private String email;
+	private String phone;
+	private String birth;
+	
+}

--- a/BookAt-Service.zip_expanded/BookAt-Service/src/main/resources/static/js/userAuth.js
+++ b/BookAt-Service.zip_expanded/BookAt-Service/src/main/resources/static/js/userAuth.js
@@ -12,7 +12,8 @@
 		  if(accessToken) {
 			axiosInstance.get('/auth/validate')
 			  .then(res => {
-			    console.log("현재 로그인 사용자:", res.data.userId);
+				const userInfo = res.data;
+			    console.log("현재 로그인 사용자:", userInfo.userId);
 			  
 			  if (loginBtn) loginBtn.style.display = 'none';
 			  if (signupBtn) signupBtn.style.display = 'none';

--- a/BookAt-Service.zip_expanded/BookAt-Service/src/main/resources/static/js/userAuthModal.js
+++ b/BookAt-Service.zip_expanded/BookAt-Service/src/main/resources/static/js/userAuthModal.js
@@ -1,0 +1,27 @@
+// 엑세스토큰이 유효한지 검증 (사용자 로그인 여부)! -> 헤더가 들어가지 않는 모달창이나 팝업창에 사용되는 용도
+
+document.addEventListener('DOMContentLoaded', () => {
+  
+  window.validateUser = async function () {
+
+	  const accessToken = localStorage.getItem("accessToken");
+	  
+	  if(!accessToken) {
+		console.log("access token 없음, 비로그인 상태");
+		window.location.href = "/";
+		return;
+	  }
+	  
+	  try {
+		const res = await axiosInstance.get("/auth/validate");
+		const userInfo = res.data;
+		console.log("현재 로그인 사용자 : ", userInfo.userId);
+	  } catch(err) {
+		console.log("로그인 상태 아님 : ", err);
+		localStorage.removeItem("accessToken");
+		window.location.href = "/";
+	  }
+	};
+
+	window.validateUser();
+});

--- a/BookAt-Service.zip_expanded/BookAt-Service/src/main/resources/templates/reservation/ReservationPopup.html
+++ b/BookAt-Service.zip_expanded/BookAt-Service/src/main/resources/templates/reservation/ReservationPopup.html
@@ -6,6 +6,9 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<title>Document</title>
 	<link rel="stylesheet" th:href="@{/css/ReservationPopup.css}" />
+	<script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
+	<script th:src="@{/js/axiosIntercepter.js}"></script>
+	<script th:src="@{/js/userAuthModal.js}"></script>
 </head>
 
 <body>


### PR DESCRIPTION
## 📌 PR 제목
<!-- 어떤 작업을 했는지 간단히 적어주세요 -->
헤더파일이 들어가지 않는 모달이나 팝업창용 사용자검증 파일 추가
userAuthModal.js -> UI변경이 전혀 일어나지 않고 로그인 된 사용자인지만 검증해서 사용자 정보를 보관
로그인하지 않는 사용자가 접근하면 홈으로 리다이렉트

## ✨ 작업 내용
<!-- 이번 PR에서 추가/변경된 내용을 적어주세요 -->
- [ ] 기능 추가 🚀사용자 정보만 보관하는 용도
- [ ] 버그 수정 🐛
- [ ] 리팩토링 🛠️
- [ ] 문서 수정 📝
- [ ] 기타 :

## 🔍 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요 (예: #12) -->
- #16 

## 🧪 테스트 방법
<!-- 어떻게 테스트했는지 간단히 적어주세요 -->
1. [ ] 로컬에서 실행 확인
2. [ ] 단위 테스트 실행
3. [ ] 브라우저 확인 : 예약 팝업창 띄울때 사용자 검증만 함 / 로그인하지 않는 사용자가 접근하면 홈으로 리다이렉트

## 💬 기타 참고 사항
<!-- 리뷰어가 알아두면 좋은 추가 정보나 배경 설명 -->
헤더가 들어가는 페이지는 userAuth.js를 써주시고, 헤더가 들어가지 않는 모달창이나 팝업창등의 페이지는 userAuthModel.js를 사용해주세요! 사용자 정보는 필요에 따라서 dto/userInfoResponse 에서 추가하셔도 됩니다.
