### PR TITLE
[BUGFIX] header.css 버그 수정 #33

### DIFF
--- a/BookAt-Service.zip_expanded/BookAt-Service/src/main/resources/static/css/header.css
+++ b/BookAt-Service.zip_expanded/BookAt-Service/src/main/resources/static/css/header.css
@@ -1,6 +1,7 @@
-
+*{
 	margin: 0;
-	padding: 0;}
+	padding: 0;
+}
 
 
 /* Header */


### PR DESCRIPTION
## 📌 PR 제목
<!-- 어떤 작업을 했는지 간단히 적어주세요 -->
-괄호 오타로 인해 헤더 배경색이 잘못 출력되는 오류 수정
-header.css에 1번줄 '*{'  추가'

## ✨ 작업 내용
<!-- 이번 PR에서 추가/변경된 내용을 적어주세요 -->
- [ ] 기능 추가 🚀
- [x] 버그 수정 🐛
- [ ] 리팩토링 🛠️
- [ ] 문서 수정 📝
- [ ] 기타 :

## 🔍 관련 이슈
<!-- 관련된 이슈 번호를 적어주세요 (예: #12) -->
- close #33 

## 🧪 테스트 방법
<!-- 어떻게 테스트했는지 간단히 적어주세요 -->
1. [x] 로컬에서 실행 확인
2. [ ] 단위 테스트 실행
3. [x] 브라우저 확인

## 💬 기타 참고 사항
<!-- 리뷰어가 알아두면 좋은 추가 정보나 배경 설명 -->

괄호 오타로 인해 배경색이 출력되지 않았던것 같습니다.

<img width="1854" height="227" alt="image" src="https://github.com/user-attachments/assets/1783115e-bc4f-47c7-a5db-8414c04ce687" />

